### PR TITLE
[Chore] 워크플로우 트리거 설정 풀리퀘스트를 푸쉬로 변경

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: CI/CD Pipeline for Spring Project
 
 # 트리거 설정: 해당 브랜치로 풀리퀘스트가 머지될 때 트리거
 on:
-  pull_request:
+  push:
     branches:
       - develop
 jobs:


### PR DESCRIPTION
## 💡 Issue
- close #31 

## 📌 Work Description
- 원래는 트리거 설정이 디벨롭 브랜치에 풀리퀘스트를 보내면 이렇게 해놨는데 이러니까 풀리퀘스트를 다른 브랜치에서 생성만 해도 actions가 돌아가길래, 디벨롭 브랜치에 푸쉬될 때 라고 변경함.

## 📝 Reference
- X

## 📚 Etc
- X