### PR TITLE
[Feat] 회원탈퇴 로직 구현

### DIFF
--- a/src/main/java/appjjang/fitpet/domain/auth/api/AuthController.java
+++ b/src/main/java/appjjang/fitpet/domain/auth/api/AuthController.java
@@ -3,7 +3,6 @@ package appjjang.fitpet.domain.auth.api;
 import appjjang.fitpet.domain.auth.application.AuthService;
 import appjjang.fitpet.domain.auth.dto.request.TokenRefreshRequest;
 import appjjang.fitpet.domain.auth.dto.response.TokenPairResponse;
-import appjjang.fitpet.global.util.MemberUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -18,7 +17,6 @@ import static appjjang.fitpet.global.common.constants.SecurityConstants.REDIRECT
 @RequestMapping("/auth")
 public class AuthController {
     private final AuthService authService;
-    private final MemberUtil memberUtil;
 
     @Operation(summary = "소셜 로그인 및 회원가입", description = "카카오 소셜 로그인을 이용하여 회원가입 및 로그인을 진행합니다.")
     @GetMapping("/login")
@@ -36,6 +34,13 @@ public class AuthController {
     @PostMapping("/logout")
     public ResponseEntity<Void> memberLogout() {
         authService.memberLogout();
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "회원탈퇴", description = "회원탈퇴를 진행합니다.")
+    @DeleteMapping("/withdrawal")
+    public ResponseEntity<Void> memberWithdrawal() {
+        authService.memberWithdrawal();
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/appjjang/fitpet/domain/auth/application/AuthService.java
+++ b/src/main/java/appjjang/fitpet/domain/auth/application/AuthService.java
@@ -56,6 +56,13 @@ public class AuthService {
         deleteRefreshToken(currentMember);
     }
 
+    public void memberWithdrawal() {
+        final Member currentMember = memberUtil.getCurrentMember();
+        kakaoService.withdrawal(Long.parseLong(currentMember.getOauthInfo().getOauthId()));
+        deleteRefreshToken(currentMember);
+        memberRepository.delete(currentMember);
+    }
+
     private void deleteRefreshToken(Member currentMember) {
         refreshTokenRepository
                 .findById(currentMember.getId())

--- a/src/main/java/appjjang/fitpet/domain/auth/application/KakaoService.java
+++ b/src/main/java/appjjang/fitpet/domain/auth/application/KakaoService.java
@@ -2,21 +2,21 @@ package appjjang.fitpet.domain.auth.application;
 
 import appjjang.fitpet.domain.auth.dto.request.KakaoTokenLoginRequest;
 import appjjang.fitpet.domain.auth.dto.response.KakaoTokenLoginResponse;
-import appjjang.fitpet.global.error.exception.CustomException;
-import appjjang.fitpet.global.error.exception.ErrorCode;
 import appjjang.fitpet.infra.config.oauth.KakaoProperties;
 import appjjang.fitpet.infra.feign.KakaoLoginClient;
+import appjjang.fitpet.infra.feign.KakaoWithdrawalClient;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-import static appjjang.fitpet.global.common.constants.SecurityConstants.LOGIN_CONTENT_TYPE_VALUE;
+import static appjjang.fitpet.global.common.constants.SecurityConstants.*;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class KakaoService {
     private final KakaoLoginClient kakaoLoginClient;
+    private final KakaoWithdrawalClient kakaoWithdrawalClient;
     private final KakaoProperties properties;
 
     public KakaoTokenLoginResponse getIdToken(String code) {
@@ -27,7 +27,19 @@ public class KakaoService {
                     );
         } catch (Exception e) {
             log.info(e.getMessage());
-            throw new CustomException(ErrorCode.BAD_KAKAO_LOGIN_REQUEST);
+            throw new IllegalArgumentException(e.getMessage());
+        }
+    }
+
+    public void withdrawal(Long oauthId) {
+        try {
+            kakaoWithdrawalClient.withdrawal(
+                    KAKAO_WITHDRAWAL_HEADER_PREFIX + properties.getAdmin(),
+                    KAKAO_WITHDRAWAL_TYPE,
+                    oauthId);
+        } catch (Exception e) {
+            log.info(e.getMessage());
+            throw new IllegalArgumentException(e.getMessage());
         }
     }
 }

--- a/src/main/java/appjjang/fitpet/global/common/constants/SecurityConstants.java
+++ b/src/main/java/appjjang/fitpet/global/common/constants/SecurityConstants.java
@@ -13,6 +13,15 @@ public final class SecurityConstants {
     public static final String LOGIN_CONTENT_TYPE_VALUE = "application/x-www-form-urlencoded;charset=utf-8";
     public static final String REDIRECT_LOGIN_CODE = "code";
 
+    public static final String KAKAO_WITHDRAWAL_URL = "https://kapi.kakao.com";
+    public static final String KAKAO_WITHDRAWAL_ENDPOINT = "/v1/user/unlink";
+    public static final String AUTHORIZATION = "Authorization";
+    public static final String KAKAO_WITHDRAWAL_HEADER_PREFIX = "KakaoAK ";
+    public static final String KAKAO_WITHDRAWAL_TYPE = "user_id";
+    public static final String KAKAO_WITHDRAWAL_URL_ENCODING = "application/x-www-form-urlencoded";
+    public static final String TARGET_ID_TYPE = "target_id_type";
+    public static final String TARGET_ID = "target_id";
+
     public static final String KAKAO_ISSUER = "https://kauth.kakao.com";
     public static final String KAKAO_JWK_SET_URL = "https://kauth.kakao.com/.well-known/jwks.json";
 }

--- a/src/main/java/appjjang/fitpet/infra/feign/KakaoWithdrawalClient.java
+++ b/src/main/java/appjjang/fitpet/infra/feign/KakaoWithdrawalClient.java
@@ -1,0 +1,17 @@
+package appjjang.fitpet.infra.feign;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import static appjjang.fitpet.global.common.constants.SecurityConstants.*;
+
+@FeignClient(name = "kakaoWithdrawalClient", url = KAKAO_WITHDRAWAL_URL)
+public interface KakaoWithdrawalClient {
+    @PostMapping(value = KAKAO_WITHDRAWAL_ENDPOINT, consumes = KAKAO_WITHDRAWAL_URL_ENCODING)
+    String withdrawal(
+            @RequestHeader(AUTHORIZATION) String authorization,
+            @RequestParam(name = TARGET_ID_TYPE) String targetIdType,
+            @RequestParam(name = TARGET_ID) Long targetId);
+}


### PR DESCRIPTION
## 💡 Issue
- close #51 

## 📌 Work Description
### 회원탈퇴 로직 구현
- 회원 탈퇴 시 연결된 카카오 계정에서도 연결이 끊기도록 구현
- 데이터베이스에 해당 사용자와 연결된 모든 데이터 삭제

## 📝 Reference
- X

## 📚 Etc
- X