### PR TITLE
[Feat] 보험을 체결한 펫의 자세한 보험 정보 조회 로직 구현

### DIFF
--- a/src/main/java/appjjang/fitpet/domain/insurance/api/InsuranceController.java
+++ b/src/main/java/appjjang/fitpet/domain/insurance/api/InsuranceController.java
@@ -1,0 +1,25 @@
+package appjjang.fitpet.domain.insurance.api;
+
+import appjjang.fitpet.domain.insurance.application.InsuranceService;
+import appjjang.fitpet.domain.insurance.dto.response.InsuranceDetailResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "보험 API", description = "보험 관련 API입니다.")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/insurances")
+public class InsuranceController {
+    private final InsuranceService insuranceService;
+
+    @Operation(summary = "보험 자세하게 조회", description = "보험을 자세하게 조회합니다.")
+    @GetMapping("/{petId}")
+    public InsuranceDetailResponse getInsuranceDetail(@PathVariable Long petId) {
+        return insuranceService.getInsuranceDetail(petId);
+    }
+}

--- a/src/main/java/appjjang/fitpet/domain/insurance/application/InsuranceService.java
+++ b/src/main/java/appjjang/fitpet/domain/insurance/application/InsuranceService.java
@@ -1,0 +1,62 @@
+package appjjang.fitpet.domain.insurance.application;
+
+import appjjang.fitpet.domain.insurance.dto.ContractDto;
+import appjjang.fitpet.domain.insurance.dto.CoverageDto;
+import appjjang.fitpet.domain.insurance.dto.response.InsuranceDetailResponse;
+import appjjang.fitpet.domain.member.domain.Member;
+import appjjang.fitpet.domain.pet.dao.PetRepository;
+import appjjang.fitpet.domain.pet.domain.Pet;
+import appjjang.fitpet.global.error.exception.CustomException;
+import appjjang.fitpet.global.error.exception.ErrorCode;
+import appjjang.fitpet.global.util.MemberUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static appjjang.fitpet.global.common.constants.InsuranceConstants.*;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class InsuranceService {
+    private final PetRepository petRepository;
+    private final MemberUtil memberUtil;
+
+    @Transactional(readOnly = true)
+    public InsuranceDetailResponse getInsuranceDetail(Long petId) {
+        final Member currentMember = memberUtil.getCurrentMember();
+        Pet pet = petRepository.findById(petId)
+                .orElseThrow(() -> new CustomException(ErrorCode.PET_NOT_FOUND));
+        validatePetOwner(currentMember, pet);
+        validateHasInsurance(pet);
+
+        String startDate = changeDateFormat(pet.getInsurance().getStartDate().toString());
+        String endDate = changeDateFormat(pet.getInsurance().getEndDate().toString());
+        String bankAccount = maskFirstFourCharacters(pet.getInsurance().getBankAccount());
+
+        return new InsuranceDetailResponse(
+                new ContractDto(pet.getInsurance(), startDate, endDate, bankAccount),
+                new CoverageDto(pet.getInsurance().getCoverage())
+        );
+    }
+
+    private String changeDateFormat(String date) {
+        return date.replace(DASH, DOT);
+    }
+
+    private String maskFirstFourCharacters(String account) {
+        return MASK + account.substring(MASK_COUNT);
+    }
+
+    private void validateHasInsurance(Pet pet) {
+        if (!pet.isInsurance()) {
+            throw new CustomException(ErrorCode.INSURANCE_NOT_FOUND);
+        }
+    }
+
+    private void validatePetOwner(Member member, Pet pet) {
+        if (!member.getPets().contains(pet)) {
+            throw new CustomException(ErrorCode.NOT_PET_OWNER);
+        }
+    }
+}

--- a/src/main/java/appjjang/fitpet/domain/insurance/domain/Insurance.java
+++ b/src/main/java/appjjang/fitpet/domain/insurance/domain/Insurance.java
@@ -3,7 +3,6 @@ package appjjang.fitpet.domain.insurance.domain;
 import appjjang.fitpet.domain.charge.domain.Charge;
 import appjjang.fitpet.domain.compensation.domain.Compensation;
 import appjjang.fitpet.domain.coverage.domain.Coverage;
-import appjjang.fitpet.domain.member.domain.Member;
 import appjjang.fitpet.domain.pet.domain.Pet;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -12,7 +11,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
-import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/appjjang/fitpet/domain/insurance/dto/ContractDto.java
+++ b/src/main/java/appjjang/fitpet/domain/insurance/dto/ContractDto.java
@@ -1,0 +1,55 @@
+package appjjang.fitpet.domain.insurance.dto;
+
+import appjjang.fitpet.domain.insurance.domain.Insurance;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class ContractDto {
+    @Schema(description = "계약자", example = "김이름")
+    private String contractor;
+
+    @Schema(description = "피보험자", example = "보리")
+    private String insurant;
+
+    @Schema(description = "보험 시작 날짜", example = "2024.09.05")
+    private String startDate;
+
+    @Schema(description = "보험 종료 날짜", example = "2024.09.05")
+    private String endDate;
+
+    @Schema(description = "보험 갱신 주기", example = "3년")
+    private String updateCycle;
+
+    @Schema(description = "보험료", example = "10000")
+    private int insuranceFee;
+
+    @Schema(description = "보상비율", example = "70%")
+    private String priceRate;
+
+    @Schema(description = "납입 방법", example = "자동이체(25일)")
+    private String payWay;
+
+    @Schema(description = "납입 계좌 은행", example = "카카오뱅크")
+    private String bank;
+
+    @Schema(description = "납입 계좌", example = "****12341234")
+    private String bankAccount;
+
+    @Schema(description = "납입 주기", example = "월납")
+    private String payCycle;
+
+    public ContractDto(Insurance insurance, String startDate, String endDate, String bankAccount) {
+        this.contractor = insurance.getContractor();
+        this.insurant = insurance.getInsurant();
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.updateCycle = insurance.getUpdateCycle();
+        this.insuranceFee = insurance.getInsuranceFee();
+        this.priceRate = insurance.getPriceRate();
+        this.payWay = insurance.getPayWay();
+        this.bank = insurance.getBank();
+        this.bankAccount = bankAccount;
+        this.payCycle = insurance.getPayCycle();
+    }
+}

--- a/src/main/java/appjjang/fitpet/domain/insurance/dto/CoverageDto.java
+++ b/src/main/java/appjjang/fitpet/domain/insurance/dto/CoverageDto.java
@@ -1,0 +1,63 @@
+package appjjang.fitpet.domain.insurance.dto;
+
+import appjjang.fitpet.domain.coverage.domain.Coverage;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class CoverageDto {
+    @Schema(description = "치료비 1일 보상한도", example = "15만원")
+    private String dailyTreatLimit;
+
+    @Schema(description = "수술비 1일 보상한도", example = "300만원 (연2회)")
+    private String dailySurgeryCostLimit;
+
+    @Schema(description = "연간 보상한도", example = "1500만원")
+    private String yearReward;
+
+    @Schema(description = "슬고관절 수술비", example = "O")
+    private String hipJointLimit;
+
+    @Schema(description = "피부병", example = "O")
+    private String skinDisease;
+
+    @Schema(description = "아포퀠/사이토포인트", example = "O")
+    private String skinEtc;
+
+    @Schema(description = "구강질환 보장", example = "O")
+    private String oralCoverage;
+
+    @Schema(description = "치과질환 보장", example = "X")
+    private String dentalCoverage;
+
+    @Schema(description = "치료비 1일 보상한도", example = "1일 보상한도 보장")
+    private String inspectionCoverage;
+
+    @Schema(description = "이물제거 보장", example = "1일 보상한도 보장")
+    private String foreignObjectRemoval;
+
+    @Schema(description = "자기부담금", example = "1만원")
+    private String selfBurden;
+
+    @Schema(description = "반려견 배상책임", example = "3000 만원")
+    private String compensationLiability;
+
+    @Schema(description = "장례지원금", example = "15만원 (만8세이상 장례비 제외)")
+    private String funeralAid;
+
+    public CoverageDto(Coverage coverage) {
+        this.dailyTreatLimit = coverage.getDailyTreatLimit();
+        this.dailySurgeryCostLimit = coverage.getDailySurgeryCostLimit();
+        this.yearReward = coverage.getYearReward();
+        this.hipJointLimit = coverage.getHipJointLimit();
+        this.skinDisease = coverage.getSkinDisease();
+        this.skinEtc = coverage.getSkinEtc();
+        this.oralCoverage = coverage.getOralCoverage();
+        this.dentalCoverage = coverage.getDentalCoverage();
+        this.inspectionCoverage = coverage.getInspectionCoverage();
+        this.foreignObjectRemoval = coverage.getForeignObjectRemoval();
+        this.selfBurden = coverage.getSelfBurden();
+        this.compensationLiability = coverage.getCompensationLiability();
+        this.funeralAid = coverage.getFuneralAid();
+    }
+}

--- a/src/main/java/appjjang/fitpet/domain/insurance/dto/response/InsuranceDetailResponse.java
+++ b/src/main/java/appjjang/fitpet/domain/insurance/dto/response/InsuranceDetailResponse.java
@@ -1,0 +1,17 @@
+package appjjang.fitpet.domain.insurance.dto.response;
+
+import appjjang.fitpet.domain.insurance.dto.ContractDto;
+import appjjang.fitpet.domain.insurance.dto.CoverageDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class InsuranceDetailResponse {
+    @Schema(description = "보험 계약")
+    private ContractDto contract;
+
+    @Schema(description = "보험 보장")
+    private CoverageDto coverage;
+}

--- a/src/main/java/appjjang/fitpet/global/common/constants/InsuranceConstants.java
+++ b/src/main/java/appjjang/fitpet/global/common/constants/InsuranceConstants.java
@@ -1,0 +1,8 @@
+package appjjang.fitpet.global.common.constants;
+
+public final class InsuranceConstants {
+    public static final String DASH = "-";
+    public static final String DOT = ".";
+    public static final String MASK = "****";
+    public static final int MASK_COUNT = 4;
+}

--- a/src/main/java/appjjang/fitpet/global/error/exception/ErrorCode.java
+++ b/src/main/java/appjjang/fitpet/global/error/exception/ErrorCode.java
@@ -21,7 +21,8 @@ public enum ErrorCode {
 
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "AJ4040", "해당 회원을 찾을 수 없습니다."),
     PET_NOT_FOUND(HttpStatus.NOT_FOUND, "AJ4041", "해당 펫을 찾을 수 없습니다."),
-    ESTIMTE_NOT_FOUND(HttpStatus.NOT_FOUND, "AJ4042", "해당 견적을 찾을 수 없습니다.")
+    ESTIMTE_NOT_FOUND(HttpStatus.NOT_FOUND, "AJ4042", "해당 견적을 찾을 수 없습니다."),
+    INSURANCE_NOT_FOUND(HttpStatus.NOT_FOUND, "AJ4043", "해당 펫의 보험을 찾을 수 없습니다.")
     ;
 
     private final HttpStatus status;


### PR DESCRIPTION
## 💡 Issue
- close #65 

## 📌 Work Description
### 체결 보험 자세한 조회 로직 구현
- 보험을 체결한 펫이 아닐 시 예외 발생
- 반환시 계좌번호의 첫 네글자 마스킹
- 편의성을 위하여 보험 계약 내용과 보험 보장 내용을 나누어 표시

## 📝 Reference
- X

## 📚 Etc
- X